### PR TITLE
fixed crash due to running Update on an empty data set

### DIFF
--- a/tabulate.go
+++ b/tabulate.go
@@ -407,6 +407,9 @@ func (t *Tabulate) wrapCellData() []*TabulateRow {
 	var arr []*TabulateRow
 	var cleanSplit bool
 	var addr int
+	if len(t.Data) == 0 {
+		return arr
+	}
 	next := t.Data[0]
 	for index := 0; index <= len(t.Data); index++ {
 		elements := next.Elements


### PR DESCRIPTION
When calling Render on an empty data set with WrapStrings set there is a crash due to an index out of range error.  The pull request just adds a simple little check to short circuit out of the function if data is empty.